### PR TITLE
Update servers.php

### DIFF
--- a/views/servers.php
+++ b/views/servers.php
@@ -6,7 +6,7 @@ if(isset($_POST['add_server']) && ($active_user->admin)) {
 		$content = new PageSection('invalid_hostname');
 		$content->set('hostname', $hostname);
 	} else {
-		$admin_names = preg_split('/[\s,]+/', $_POST['admins'], -1, PREG_SPLIT_NO_EMPTY);
+		$admin_names = preg_split('/(,\s)+/', $_POST['admins'], -1, PREG_SPLIT_NO_EMPTY);
 		$admins = array();
 		foreach($admin_names as $admin_name) {
 			$admin_name = trim($admin_name);


### PR DESCRIPTION
Fix "User not found" error - allow groups with a white spaces in their name. However the group names should not have a "," in their name. If this is required, the "separator" could be changed in [public_html/extra.js#L405](https://github.com/nisenbeck/ssh-key-authority/blob/master/public_html/extra.js#L405) as well as in [views/servers.php#L9](https://github.com/nisenbeck/ssh-key-authority/blob/master/views/servers.php#L9).